### PR TITLE
Hack to allow Capitalism2/CapLab's custom double-buffer system to draw.

### DIFF
--- a/src/IDirectDraw/IDirectDrawSurface.c
+++ b/src/IDirectDraw/IDirectDrawSurface.c
@@ -104,6 +104,7 @@ ULONG __stdcall IDirectDrawSurface__Release(IDirectDrawSurfaceImpl *This)
 HRESULT __stdcall IDirectDrawSurface__AddAttachedSurface(IDirectDrawSurfaceImpl *This, LPDIRECTDRAWSURFACE lpDDSurface)
 {
     dprintf("-> %s(This=%p, lpDDSurface=%p)\n", __FUNCTION__, This, lpDDSurface);
+    ((IDirectDrawSurfaceImpl*) lpDDSurface)->surface = This->surface;
     HRESULT ret = dds_AddAttachedSurface(This, lpDDSurface);
     dprintf("<- %s\n", __FUNCTION__);
     return ret;


### PR DESCRIPTION
Caplab seems to use some non-standard double-buffering system, wherein the dev creates three surfaces, one presentation surface and two working surfaces (call them A and B). The two working surfaces are Attached together, and the game will blit into surface B, then when the frame is done blit A into the presentation surface. It seems that this system relies on some arcane property of Surface Attachments to copy or rotate from B into A, but afaict only the official windows ddraw.dll actually works this way, and this has been a complaint on [Wine](https://appdb.winehq.org/objectManager.php?sClass=version&iId=30640&iTestingId=85612&bShowAll=true) for years. When debugging the issue, I was able to get the rendering system working by making AddAttachSurface link both surfaces to the same backend buffer, thus """"fixing"""" the bug, but I can't fathom all the potential damage this would cause, so I'm leaving this here with a massive asterisk and a request to maybe find a better way to do this, or at least gate it behind a config option.

